### PR TITLE
Release/0.1.2 pre alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Tue Feb  9 16:19:48 UTC 2021
-# camelforth-rp2040-aU   UNSTABLE   0.1.1-pre-alpha   Tue Feb  9 16:19:48 UTC 2021
+# camelforth-rp2040-aU   UNSTABLE   0.1.0-pre-alpha   Tue Feb  9 16:26:59 UTC 2021
+
+Correction: never was a tag or a release - did not 'git tag -d <thistag>' as proper(?)
 
 UNSTABLE version - new feature: LED blinking.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# camelforth-rp2040-aU   UNSTABLE   0.1.0-pre-alpha   Tue Feb  9 16:26:59 UTC 2021
+# camelforth-rp2040-aU   UNSTABLE   0.1.2-pre-alpha   Tue Feb  9 16:35:45 UTC 2021
 
-Correction: never was a tag or a release - did not 'git tag -d <thistag>' as proper(?)
+Corrections made - decided a new unused tag was the only permissible option.
+
+(Who knew)
 
 UNSTABLE version - new feature: LED blinking.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Tue Feb  9 11:10:49 UTC 2021
-# camelforth-rp2040-aU   UNSTABLE   0.1.0-pre-alpha   Tue Feb  9 11:10:49 UTC 2021
+# Tue Feb  9 16:19:48 UTC 2021
+# camelforth-rp2040-aU   UNSTABLE   0.1.1-pre-alpha   Tue Feb  9 16:19:48 UTC 2021
 
-UNSTABLE version - new features such as LED blinking.
+UNSTABLE version - new feature: LED blinking.
 
 CamelForth in C, by Dr. Brad Rodriguez
 
-Reasonably well debugged - functional Forth interpreter 04:10 UTC Tue 09 Feb 2021
+Reasonably well debugged - functional Forth interpreter.
 
 Port: rp2040, Raspberry Pi Pico target board, February, 2021.
 
@@ -25,6 +25,8 @@ Forth interpreter for the
 RP2040 and Raspberry Pi Pico.
 
 UNSTABLE version.  Look for changes and improvements here.
+
+New feature: the blink word.  Use once per blink.
 
 Requires pico-sdk and is modeled on pico-examples.
 


### PR DESCRIPTION
Several attempts to do a correct tag but reusing old ones was not permissible.

'old ones' here means from the cloned repository.  The system seems repository-agnostic when it comes to tagging - if the edit history is the same, the tagging history is (essentially) shared.  Or, that's how it seems.

THIS release has a prebuilt CamelForth .UF2 that has the 'blink' word added - hardware support to blink the GPIO pin of the on-board LED for the Raspberry Pi Pico target board (RP2040 based).