### PR TITLE
Ready for release 0.1.3-pre-alpha Wed Feb 10 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# camelforth-rp2040-aU   UNSTABLE   0.1.2-pre-alpha   Tue Feb  9 16:35:45 UTC 2021
-
-Corrections made - decided a new unused tag was the only permissible option.
-
-(Who knew)
+# camelforth-rp2040-aU   UNSTABLE   0.1.3-pre-alpha   Wed Feb 10 04:08:51 UTC 2021
 
 UNSTABLE version - new feature: LED blinking.
 
 CamelForth in C, by Dr. Brad Rodriguez
 
 Reasonably well debugged - functional Forth interpreter.
+
+There is one bug where it crashes unexpectedly, after
+a decently long runtime.  maybe 'run' gets set by .. don't know.
+
+Seems to print endless nulls '@' but have not captured to
+log to verify that's what it is.
 
 Port: rp2040, Raspberry Pi Pico target board, February, 2021.
 


### PR DESCRIPTION
camelforth-rp2040-aU   0.1.3-pre-alpha  Wed Feb 10 04:08 UTC 2021

	modified:   README.md

On branch develop

Still has '@' bug - interpreter may be running on empty (run flag may be wrong).
A few short forth definitions shown in an quick_foo.fs file that are easy to
paste into the controlling terminal (picocom is reference terminal program).

This is likely correct, there:

picocom -e \\ -f n -p n -d 8 -b 115200 --omap delbs,lfcr --send-cmd "ascii-xfr -s -l 1850 -c 10" ${1}
